### PR TITLE
[FEAT] Add Dockerfile for container building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,13 +35,10 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           registry: ghcr.io
-          username: $GITHUB_USER
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: searls
+          password: ${{ secrets.CH_PAT }}
       - name: Calculate Docker tags
         id: tags
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,3 +25,35 @@ jobs:
         bundler-cache: true
     - name: Run the default task
       run: bundle exec rake
+
+  docker:
+    runs-on: ubuntu-latest
+    name: Build Docker Container
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          registry: ghcr.io
+          username: $GITHUB_USER
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Calculate Docker tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/searls/feed2gram:${{ github.event.pull_request.head.sha || github.sha }}"
+          if [ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]; then
+            TAGS="$(printf "$TAGS\nghcr.io/searls/feed2gram:latest")"
+          fi
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ruby:3.2.2
 
+LABEL org.opencontainers.image.source=https://github.com/searls/feed2gram
+LABEL org.opencontainers.image.description="Reads an Atom feed and posts its entries to Instagram (basically feed2toot, but for Instagram)"
+LABEL org.opencontainers.image.licenses=GPLv3
+
 WORKDIR /srv
 COPY Gemfile Gemfile.lock feed2gram.gemspec .
 COPY lib/feed2gram/version.rb lib/feed2gram/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:3.2.2
+
+WORKDIR /srv
+COPY Gemfile Gemfile.lock feed2gram.gemspec .
+COPY lib/feed2gram/version.rb lib/feed2gram/
+RUN bundle install
+ADD . .
+ENTRYPOINT ["/srv/exe/feed2gram"]

--- a/README.md
+++ b/README.md
@@ -82,12 +82,23 @@ directory. This file is used internally by feed2gram to keep track of which
 entry URLs in the atom feed have been processed and can be ignored on the next
 run.
 
+## Docker
+
+You can also use Docker to run this on your own automation platform like Proxmox or Kubernetes.
+
+```
+docker run --rm -it \
+  -v ./feed2gram.yml:/srv/feed2gram.yml \
+  -v ./feed2gram.cache.yml:/srv/feed2gram.cache.yml \
+  ghcr.io/searls/feed2gram
+```
+
 ## Options
 
 For available options, run `feed2gram --help`:
 
 ```
-$ ./script/run --help
+$ ./exe/feed2gram --help
 Usage: feed2gram [options]
   --config PATH        Path of feed2gram YAML configuration (default: feed2gram.yml)
   --cache-path PATH    Path of feed2gram's cache file to track processed entries (default: feed2gram.cache.yml)


### PR DESCRIPTION
This will let you build a Docker container and use the resulting image directly without having to have Ruby installed.

This also adds some CI automation to build the container image after the tests pass and push the resulting image. On pushes to `main`, it will tag the image as `latest` for easier execution.