### PR TITLE
[BUG] Fix small issue generating $TAGS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,16 @@ jobs:
       - name: Calculate Docker tags
         id: tags
         run: |
-          TAGS="ghcr.io/searls/feed2gram:${{ github.event.pull_request.head.sha || github.sha }}"
+          echo "tags<<EOTAGS" >> "$GITHUB_OUTPUT"
+          echo "ghcr.io/searls/feed2gram:${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_OUTPUT"
           if [ "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]; then
-            TAGS="$(printf "$TAGS\nghcr.io/searls/feed2gram:latest")"
+            echo "ghcr.io/searls/feed2gram:latest" >> "$GITHUB_OUTPUT"
           fi
-          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            GIT_TAG=${GITHUB_REF#refs/tags/v}
+            echo "ghcr.io/searls/feed2gram:${GIT_TAG}" >> "$GITHUB_OUTPUT"
+          fi
+          echo "EOTAGS" >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,10 @@ jobs:
           echo "EOTAGS" >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@v5
         with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
Tag version numbers from `git tag` number schemes.
Add GHA cache support to the docker build step.
Fix `latest` tag on pushes to `main`.
Do not push images on PRs, only on `main`.